### PR TITLE
Define clinician input/output reading

### DIFF
--- a/include/platform/clinician_input.h
+++ b/include/platform/clinician_input.h
@@ -13,3 +13,45 @@
  *
  */
 status_t get_respiratory_rate(uint32_t * RR);
+
+/*
+ * Updates I:E ratio (inspiratory-expiratory) variable IE 
+ * when a valid value was read from the clinician inputs
+ * 
+ * @return STATUS_OK if I:E ratio is valid 
+ *         STATUS_ERR if the I:E ratio is invalid
+ *
+ */
+status_t get_ie_ratio(uint32_t * IE);
+
+/*
+ * Updates breaths per minute variable BPM 
+ * when a valid value was read from the clinician inputs
+ * 
+ * @return STATUS_OK if breaths per minute value is valid 
+ *         STATUS_ERR if the breaths per minute value is invalid
+ *
+ */
+status_t get_breaths_per_minute(uint32_t * BPM);
+
+/*
+ * Updates acceptable exhaled tidal volume variable ML 
+ * when a valid value was read from the clinician inputs
+ * 
+ * @return STATUS_OK if acceptable exhaled tidal volume is valid 
+ *         STATUS_ERR if the acceptable exhaled tidal volume is invalid
+ *
+ */
+status_t get_acceptable_exhaled_tidal_volume(uint32_t * ML);
+
+/*
+ * Updates ventilation mode variable VM 
+ * when a valid value was read from the clinician inputs
+ * 
+ * @return STATUS_OK if ventilation mode is valid 
+ *         STATUS_ERR if the ventilation mode is invalid
+ *
+ */
+status_t get_ventilation_mode(enum VM);
+
+

--- a/include/platform/pressureFlowSensor.h
+++ b/include/platform/pressureFlowSensor.h
@@ -10,12 +10,17 @@
 #ifndef INC_PLATFORM_PRESSURE_FLOW_SENSOR_H_
 #define INC_PLATFORM_PRESSURE_FLOW_SENSOR_H_
 
+uint32_t read_FS6122_sensor(uint8_t, uint8_t);
+
 /*
  * Reads and validates the read inspiratory pressure
  * Updates the measurement inputs
  *
- * returns the inspiratory pressure in ??? when it is valid
- * returns ??? when no valid pressure is available
+ *  Validation: 
+ *      -5 ~ +40 [cmH2O]
+ * 
+ * returns the inspiratory pressure in cmH2O when it is valid
+ * returns cmH2O when no valid pressure is available
  *
  */
 int get_inspiratory_pressure();
@@ -23,9 +28,12 @@ int get_inspiratory_pressure();
 /*
  * Reads and validates the read expiratory pressure
  * Updates the measurement inputs
+ * 
+ * Validation: 
+ *      -5 ~ +40 [cmH2O]
  *
- * returns the expiratory pressure in ??? when it is valid
- * returns ??? when no valid pressure is available
+ * returns the expiratory pressure in cmH2O when it is valid
+ * returns cmH2O when no valid pressure is available
  */
 int get_expiratory_pressure();
 
@@ -33,17 +41,23 @@ int get_expiratory_pressure();
  * Reads and validates the read inspiratory flow
  * Updates the measurement inputs
  *
- * returns the inspiratory flow in ??? when it is valid
- * returns ??? when no valid flow is available
+ * Validation: 
+ *      flow between -250 ~ +250 SLPM
+ * 
+ * returns the inspiratory flow in SLPM when it is valid
+ * returns SLPM when no valid flow is available
  */
 int get_inspiratory_flow();
 
 /*
  * Reads and validates the read expiratory flow
  * Updates the measurement inputs
+ * 
+ * Validation: 
+ *      flow between -250 ~ +250 SLPM
  *
- * returns the expiratory flow in ??? when it is valid
- * returns ???  when no valid flow is available
+ * returns the expiratory flow in SLPM when it is valid
+ * returns SLPM when no valid flow is available
  */
 int get_expiratory_flow();
 


### PR DESCRIPTION
This branch implements function definitions for reading the clinician settable parameters. 

Based on SRS Table of Inputs, the following clinician-settable parameters have been defined: 

- Selected Respiratory Rate
- Selected I:E ratio
- Selected Input for modification
- Acceptable breaths per minute averaged over 30 sec
- Acceptable exhaled tidal volume value
- Ventilation mode

The following parameters still need to be implemented in this file: 
- Measured inspiratory pressure
- Measured inspiratory flow
- Measured Pressure at Expiratory Valve
- Measured expiratory flow



